### PR TITLE
Subdirectory pagination fix

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -27,7 +27,7 @@
 				</div>
 			</div>
 
-			{{ partial "pagination.html" $paginator }}
+			{{ partial "pagination.html" (dict "paginator" $paginator "site" .Site ) }}
 
 		</main>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
 				</div>
 			</div>
 
-			{{ partial "pagination.html" $paginator }}
+			{{ partial "pagination.html" (dict "paginator" $paginator "site" .Site ) }}
 
 		</main>
 

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,11 +1,13 @@
 <nav id="pagination" class="pagination" role="pagination">
 	<div class="inner">
-	{{if .HasPrev}}
-	  <a class="pagination-item pagination-next" href="{{ .Prev.URL }}"><i class="icon-arrow-left"></i> <span>Newer Posts</span></a>
+	{{if .paginator.HasPrev}}
+		{{ $prevUrl := delimit (slice .site.BaseURL .paginator.Prev.URL) "" }}
+	  <a class="pagination-item pagination-next" href="{{ $prevUrl }}"><i class="icon-arrow-left"></i> <span>Newer Posts</span></a>
 	{{end}}
-		<span class="pagination-info">Page {{ .PageNumber }} of {{.TotalPages}}</span>
-	{{if .HasNext}}
-	  <a class="pagination-item pagination-prev" href="{{ .Next.URL }}"><span>Older Posts</span> <i class="icon-arrow-right"></i></a>
+		<span class="pagination-info">Page {{ .paginator.PageNumber }} of {{.paginator.TotalPages}}</span>
+	{{if .paginator.HasNext}}
+		{{ $nextUrl := delimit (slice .site.BaseURL .paginator.Next.URL) "" }}
+	  <a class="pagination-item pagination-prev" href="{{ $nextUrl }}"><span>Older Posts</span> <i class="icon-arrow-right"></i></a>
 	{{end}}
 		<div class="clear"></div>
 	</div>


### PR DESCRIPTION
Closes #26

Site BaseUrl passed to the pagination partial so that it can be prepended to the previous/next Urls.