### PR TITLE
Prepend BaseURL to image in List

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -7,7 +7,7 @@
 		<a class="post-link" href="{{ .Permalink }}"></a>
 		{{ if .Params.image }}
 		<figure class="post-image">
-			<a href="{{ .Permalink }}"><img src="{{ .Params.image }}" alt="" /></a>
+			<a href="{{ .Permalink }}"><img src="{{ .Site.BaseURL }}{{ .Params.image }}" alt="" /></a>
 		</figure>
 		{{ end }}
 		<span class="post-meta">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-theme-bleak",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Bleak Hugo Theme",
   "author": "Thibault NORMAND",
   "repository": {


### PR DESCRIPTION
PR prepends the `.BaseURL` to the start of the image paths in the list view of the blog pages.

This fixes an issue with the image paths on subsequent pages and on the tag pages. For example:

 - /page/2
 - /tags/my-tag