### PR TITLE
Remove ellipsis if no description 

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -14,7 +14,9 @@
 			<span class="post-date">{{ .Date.Format "2 Jan 2006" }}</span>
 		</span>
 		<h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+		{{ if .Description }}
 		<p class="post-excerpt">{{ .Description }}&hellip;</p>
+		{{ end }}
 		<span class="post-more"><a href="{{ .Permalink }}">Read More <i class="icon-arrow-right"></i></a></span>
 	</div>
 </article>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-theme-bleak",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Bleak Hugo Theme",
   "author": "Thibault NORMAND",
   "repository": {


### PR DESCRIPTION
PR removes ellipsis from posts if no description is provided.

**Before**

<img width="393" alt="screen shot 2017-11-17 at 17 43 53" src="https://user-images.githubusercontent.com/15653985/32961046-f73e13e8-cbbe-11e7-97a2-0077ccbc1fa3.png">


**After**

<img width="394" alt="screen shot 2017-11-17 at 17 44 07" src="https://user-images.githubusercontent.com/15653985/32961055-fd076144-cbbe-11e7-9c1b-8ce9a03903e8.png">
