### PR TITLE
use site title for home header if no logo or gravatar

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -148,6 +148,8 @@
       			  	<img src="{{ .Site.Params.logo }}" alt="Logo"/>
       			  {{ else if .Site.Params.author.gravatarHash }}
       				  <img src="https://www.gravatar.com/avatar/{{ .Site.Params.author.gravatarHash }}.png?s=32" alt="Logo"/>
+      			  {{ else }}
+      				  {{ .Site.Title }}
       			  {{ end }}
               </a>
             </div>


### PR DESCRIPTION
I wanted to be able to postpone creating a site logo, so I made it able to default to using the site's title instead of a logo